### PR TITLE
Cfg.Targets.Linux.Common.Deb.DesktopEntry.MimeType

### DIFF
--- a/config_schema/config.schema.v1.json
+++ b/config_schema/config.schema.v1.json
@@ -196,6 +196,10 @@
           "type": "string",
           "description": "Desktop entry type. If empty, \"Application\" will be used"
         },
+        "mime_type": {
+          "type": "string",
+          "description": "Desktop entry mime type."
+        },
         "terminal": {
           "type": "boolean",
           "description": "Desktop entry Terminal key.\nIf empty, `true` will be used"

--- a/pkg/pipeline/config/cfgtypes/linux.go
+++ b/pkg/pipeline/config/cfgtypes/linux.go
@@ -25,6 +25,8 @@ type TargetLinuxDebDesktopEntry struct {
 	// Desktop entry NoDisplay key.
 	// If empty, `false` will be used
 	NoDisplay *bool `json:"no_display,omitempty"`
+	// Desktop entry mime type.
+	MimeType string `json:"mime_type,omitempty"`
 }
 
 type TargetLinuxDeb struct {

--- a/pkg/pipeline/config/prepare.go
+++ b/pkg/pipeline/config/prepare.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/cardinalby/go-dto-merge"
+	dtomerge "github.com/cardinalby/go-dto-merge"
 	"github.com/cardinalby/xgo-pack/pkg/go_src"
 	"github.com/cardinalby/xgo-pack/pkg/pipeline/config/cfgtypes"
 	"github.com/cardinalby/xgo-pack/pkg/pipeline/config/presets"
@@ -180,7 +180,6 @@ func FillDefaults(c *cfgtypes.Config) (err error) {
 	if c.Targets.Linux.Common.Deb.DesktopEntry.NoDisplay == nil {
 		c.Targets.Linux.Common.Deb.DesktopEntry.NoDisplay = typeutil.Ptr(false)
 	}
-
 	return nil
 }
 

--- a/pkg/platforms/linux/deb_pkg/desktop_entry.go
+++ b/pkg/platforms/linux/deb_pkg/desktop_entry.go
@@ -17,6 +17,7 @@ type DesktopEntry struct {
 	Terminal  bool
 	Icon      string
 	NoDisplay bool
+	MimeType  string
 }
 
 func (d *DesktopEntry) Marshall() []byte {
@@ -28,6 +29,9 @@ func (d *DesktopEntry) Marshall() []byte {
 	sb.WriteString("Terminal=" + strconv.FormatBool(d.Terminal) + "\n")
 	sb.WriteString("Icon=" + d.Icon + "\n")
 	sb.WriteString("NoDisplay=" + strconv.FormatBool(d.NoDisplay) + "\n")
+	if d.MimeType != "" {
+		sb.WriteString("MimeType=" + d.MimeType + "\n")
+	}
 	return []byte(sb.String())
 }
 
@@ -45,6 +49,7 @@ func registerDesktopEntryBuilder(ctx buildctx.Context) {
 			Terminal:  typeutil.PtrValueOr(ctx.Cfg.Targets.Linux.Common.Deb.DesktopEntry.Terminal, true),
 			Icon:      ctx.Cfg.Targets.Linux.Common.Deb.DesktopEntry.DstIconPath,
 			NoDisplay: typeutil.PtrValueOrDefault(ctx.Cfg.Targets.Linux.Common.Deb.DesktopEntry.NoDisplay),
+			MimeType:  ctx.Cfg.Targets.Linux.Common.Deb.DesktopEntry.MimeType,
 		}
 		if err := fsutil.WriteFile(file.Path, entry.Marshall()); err != nil {
 			return nil, fmt.Errorf("error writing '%s' file: %w", file.Path, err)


### PR DESCRIPTION
This will add the ability to use xgo-pack not only for GUI programs, but also for console programs that accept files from file browsers as parameters.